### PR TITLE
Add middle C offset option to track

### DIFF
--- a/app/rfx.lua
+++ b/app/rfx.lua
@@ -975,6 +975,8 @@ function rfx.Track:initialize()
     -- are regenerated (e.g. because reabank.parseall() is called) then this table must be
     -- regenerated via rfx.Track:index_banks_by_channel_and_check_hash()
     self.banks_by_channel = nil
+    -- Track specific options
+    self.middle_c_offset = 0
     self:reset()
 end
 
@@ -1556,6 +1558,12 @@ function rfx.Track:sync_banks_to_rfx()
                         local outbus = output.bus or bank.dstbus or 1
                         local param1 = tonumber(output.args[1] or 0)
                         local param2 = tonumber(output.args[2] or 0)
+                        if output.type == 'note' then
+                            -- offset the note based on middle C octave offset.
+                            if self.current ~= nil then
+                                param1 = param1 + self.current.middle_c_offset * 12
+                            end
+                        end
                         if not output.route then
                             -- Set bit 7 of param1 if this output event should not setup routing
                             param1 = param1 | 0x80

--- a/app/screens/trackcfg.lua
+++ b/app/screens/trackcfg.lua
@@ -151,6 +151,22 @@ function screen.init()
         end
     })
 
+    section:add(rtk.Text{'Middle C Mappping (from C4):'}, {valign='left'})
+    local middle_c_map = section:add(rtk.OptionMenu{
+        menu={
+            {'C3', id='C3', offset=-1},
+            {'C4', id='C4', offset=0},
+            {'C5', id='C5', offset=1},
+        },
+    })
+    middle_c_map.onchange = function(self, item)
+        if rtk.current ~= nil then
+            rtk.current.middle_c_offset = item.offset
+            rfx.current:sync_banks_to_rfx()
+        end
+    end
+    middle_c_map:select('C4')
+
     -- Build menus for src and dst channels
     screen.src_channel_menu = {{'Omni', id=17}}
     for i = 1, 16 do


### PR DESCRIPTION
Add an option to the track options to set an offset to the middle C relative to the C4 standard. Some VST expect middle C map to C3. So note keyswitch should be offset by 12. 

This PR does not quite work yet, I want to get some feedback first before I spend too much time. A few things I don't know how to do. For example, how do I see the log outputs for debugging?

The idea is fairly simple:
1. we want this to be a track specific feature because some VST assumes C maps to C4, some assumes C3. 
2. allow user to specify how the note based on C4 (standard) should mapped to. Options provided are C3 (-1 octave), C4 (no change), C5 (+1 octave).
3. During sync_banks_to_rfx() call, we offset the note to be trigged by this track specific offset, i.e. offset * 12.
4. When user make a change to this selection, we call sync_banks_to_rfx() to update.

Also probably should update note_to_name() to reflect this offset.

Not sure what I'm missing, but it does not seems to work yet.