### PR TITLE
Add banks for EastWest Hollywood Opus

### DIFF
--- a/userbanks/EastWest_Hollywood_Opus_Brass.reabank
+++ b/userbanks/EastWest_Hollywood_Opus_Brass.reabank
@@ -1,0 +1,220 @@
+//----------------------------------------------------------------------------
+// Source xshill: https://github.com/jtackaberry/reaticulate/pull/211
+//----------------------------------------------------------------------------
+
+//! g="EastWest/Hollywood Opus Brass" n="2FH KS Master"
+//! m=""
+//! id=4dca6b9e-a239-433b-93d4-db4757c41f03
+Bank * * 2FH KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short-dark i=marcato-quarter o=note:28
+52 Marcato Short
+//! c=long-dark i=marcato-half o=note:29
+9 Marcato Long
+
+//! g="EastWest/Hollywood Opus Brass" n="2TB KS Master"
+//! m=""
+//! id=957290b7-f0c1-42d3-8c85-8704f592b16e
+Bank * * 2TB KS Master
+//! c=long i=note-half o=note:74
+1 Sus
+//! c=long i=accented-half o=note:75
+2 Sus Accent
+//! c=short-light i=spiccato o=note:76
+42 Staccatissimo
+//! c=short i=staccato o=note:77
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:78
+52 Marcato Short
+//! c=long-dark i=marcato-half o=note:79
+9 Marcato Long
+
+//! g="EastWest/Hollywood Opus Brass" n="3TB KS Master"
+//! m=""
+//! id=5b239442-9075-467b-9230-f6fc6f09eaac
+Bank * * 3TB KS Master
+//! c=long i=note-half o=note:84
+1 Sus
+//! c=long i=accented-half o=note:85
+2 Sus Max
+//! c=legato i=legato o=note:86
+20 Leg Slur
+//! c=short-light i=spiccato o=note:87
+42 Staccatissimo
+//! c=short-dark i=marcato-quarter o=note:88
+9 Marcato Short
+//! c=long-dark i=marcato-half o=note:89
+52 Marcato Long
+
+//! g="EastWest/Hollywood Opus Brass" n="2TP KS Master"
+//! m=""
+//! id=0e40466d-6e9f-4352-b699-01486b1903d1
+Bank * * 2TP KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short-dark i=marcato-quarter o=note:28
+52 Marcato Short
+//! c=long-dark i=marcato-half o=note:29
+9 Marcato Long
+
+//! g="EastWest/Hollywood Opus Brass" n="2TPx KS Master"
+//! m=""
+//! id=51ecd1eb-fc81-4bf9-b48c-c3997a1da01c
+Bank * * 2TPx KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Brass" n="3TP KS Master"
+//! m=""
+//! id=0cc445ce-f737-427d-9b67-de73f33f8f64
+Bank * * 3TP KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Brass" n="6FH KS Master"
+//! m=""
+//! id=065a2506-fed5-41b7-84fb-59d4c4f0b9be
+Bank * * 6FH KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short i=staccato o=note:27
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:28
+52 Marcato Short
+//! c=long-dark i=marcato-half o=note:29
+9 Marcato Long
+
+//! g="EastWest/Hollywood Opus Brass" n="LB KS Master"
+//! m=""
+//! id=32832720-ae21-4a9e-8380-cecdbfa13ae7
+Bank * * LB KS Master
+//! c=long i=note-half o=note:60
+1 Sus
+//! c=long i=accented-half o=note:61
+2 Sus Accent
+//! c=short-light i=spiccato o=note:62
+42 Staccatissimo
+//! c=long-light i=con-sord o=note:63
+7 Mute Sus
+//! c=long-light i=con-sord-bow-up o=note:64
+8 Mute Sus Accent
+//! c=short-light i=staccato-con-sord o=note:65
+47 Mute Stac
+
+//! g="EastWest/Hollywood Opus Brass" n="1CM KS Master"
+//! m=""
+//! id=b1c9b98f-e47a-46c0-9f98-b8e5a25ebaae
+Bank * * 1CM KS Master
+//! c=long i=accented-half o=note:62
+2 Sus Accent
+//! c=short-light i=spiccato o=note:63
+42 Staccatissimo
+//! c=short-dark i=marcato-quarter o=note:64
+52 Marcato Short
+//! c=long-dark i=marcato-half o=note:65
+9 Marcato Sus
+
+//! g="EastWest/Hollywood Opus Brass" n="1FH KS Master"
+//! m=""
+//! id=3879f6e6-7d4d-44a8-97eb-bcaf152b2802
+Bank * * 1FH KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short-dark i=marcato-quarter o=note:28
+52 Marcato Short
+//! c=long-dark i=marcato-half o=note:29
+9 Marcato Long
+
+//! g="EastWest/Hollywood Opus Brass" n="1TB KS Master"
+//! m=""
+//! id=fb7627d7-b014-43c9-9bb8-527193ef6f9b
+Bank * * 1TB KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short-dark i=marcato-quarter o=note:28
+52 Marcato Short
+//! c=long-dark i=marcato-half o=note:29
+9 Marcato Long
+
+//! g="EastWest/Hollywood Opus Brass" n="1TP KS Master"
+//! m=""
+//! id=47207e3c-4800-45fb-b233-f35f46ecd5c2
+Bank * * 1TP KS Master
+//! c=long i=note-half o=note:24
+1 Sus Non Vib
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Brass" n="1TU KS Master"
+//! m=""
+//! id=dbff86b6-252e-43cf-88d9-05cf8db1e1fe
+Bank * * 1TU KS Master
+//! c=long i=note-half o=note:60
+1 Sus
+//! c=long i=accented-half o=note:61
+2 Sus Accent
+//! c=legato i=legato o=note:62
+20 Leg Slur
+//! c=short-light i=spiccato o=note:63
+42 Staccatissimo
+//! c=short-dark i=marcato-quarter o=note:64
+52 Marcato Short
+//! c=long-dark i=marcato-half o=note:65
+9 Marcato Long

--- a/userbanks/EastWest_Hollywood_Opus_Harp.reabank
+++ b/userbanks/EastWest_Hollywood_Opus_Harp.reabank
@@ -1,0 +1,20 @@
+//----------------------------------------------------------------------------
+// Source xshill: https://github.com/jtackaberry/reaticulate/pull/211
+//----------------------------------------------------------------------------
+
+//! g="EastWest/Hollywood Opus Harp" n="Harp KS Master"
+//! m=""
+//! id=dcfceefe-0f76-49c8-aab4-7fe267d1df9f
+Bank * * Harp KS Master
+//! c=long i=tremolo o=note:21
+1 Sus RR Bisbigliando MOD
+//! c=long-light i=tremolo o=note:22
+2 Maestro Bisbigliando MOD
+//! c=long-dark i=tremolo o=note:23
+9 Angels Bisbigliando MOD
+//! c=short i=staccato o=note:24
+40 Pluck Long
+//! c=short-dark i=staccato-dig o=note:25
+49 Thumb Pick
+//! c=short-light i=spiccato-feathered o=note:26
+48 Nail Pick

--- a/userbanks/EastWest_Hollywood_Opus_Percussion.reabank
+++ b/userbanks/EastWest_Hollywood_Opus_Percussion.reabank
@@ -1,0 +1,33 @@
+//----------------------------------------------------------------------------
+// Source xshill: https://github.com/jtackaberry/reaticulate/pull/211
+//----------------------------------------------------------------------------
+
+//! g="EastWest/Hollywood Opus Percussion" n="Timpani Flt KS"
+//! m=""
+//! id=1a7996dc-95d9-4c46-a290-2fefd3cf6c27
+Bank * * Timpani Flt KS
+//! c=long i=note-whole o=note:24
+1 Long
+//! c=short i=note-quarter o=note:25
+40 Short
+//! c=short i=acciaccatura-quarter o=note:26
+41 Flam
+//! c=long i=tremolo o=note:27
+11 Rolls
+//! c=long i=crescendo o=note:28
+102 Crescendo
+
+//! g="EastWest/Hollywood Opus Percussion" n="Timpani Hrd KS"
+//! m=""
+//! id=3dcda2c9-8376-42f6-88d2-90706bf37f8b
+Bank * * Timpani Hrd KS
+//! c=long i=note-whole o=note:24
+1 Long
+//! c=short i=note-quarter o=note:25
+40 Short
+//! c=short i=acciaccatura-quarter o=note:26
+41 Flam
+//! c=long i=tremolo o=note:27
+11 Rolls
+//! c=long i=crescendo o=note:28
+102 Crescendo

--- a/userbanks/EastWest_Hollywood_Opus_Solo_Cello.reabank
+++ b/userbanks/EastWest_Hollywood_Opus_Solo_Cello.reabank
@@ -1,0 +1,20 @@
+//----------------------------------------------------------------------------
+// Source xshill: https://github.com/jtackaberry/reaticulate/pull/211
+//----------------------------------------------------------------------------
+
+//! g="EastWest/Hollywood Opus Solo Cello" n="Solo Cello KS Master"
+//! m=""
+//! id=8bd05abe-5724-4998-9b54-498b9411dc90
+Bank * * Solo Cello KS Master
+//! c=long i=note-whole o=note:24
+1 Sus NV NV VB Solo
+//! c=long i=vibrato o=note:25
+2 Sus NV VB VB Solo
+//! c=legato i=legato o=note:26
+20 Legato Slur
+//! c=short-light i=spiccato o=note:27
+42 Spiccato
+//! c=short-dark i=marcato-quarter o=note:28
+52 Marcato Short
+//! c=long-dark i=marcato-half o=note:29
+9 Marcato Long

--- a/userbanks/EastWest_Hollywood_Opus_Solo_Violin.reabank
+++ b/userbanks/EastWest_Hollywood_Opus_Solo_Violin.reabank
@@ -1,0 +1,20 @@
+//----------------------------------------------------------------------------
+// Source xshill: https://github.com/jtackaberry/reaticulate/pull/211
+//----------------------------------------------------------------------------
+
+//! g="EastWest/Hollywood Opus Solo Violin" n="Solo Violin KS Master"
+//! m=""
+//! id=d97a14c3-afff-4672-9f5d-b0b9ab53b24e
+Bank * * Solo Violin KS Master
+//! c=long i=note-whole o=note:24
+1 Sus NV NV VB Solo
+//! c=long i=vibrato o=note:25
+2 Sus NV VB VB Solo
+//! c=legato i=legato o=note:26
+20 Legato Slur
+//! c=short-light i=note-quarter o=note:27
+42 Spiccato
+//! c=short-dark i=tenuto-eighth o=note:28
+50 Martele
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short Vib

--- a/userbanks/EastWest_Hollywood_Opus_Strings.reabank
+++ b/userbanks/EastWest_Hollywood_Opus_Strings.reabank
@@ -1,0 +1,351 @@
+//----------------------------------------------------------------------------
+// Source xshill: https://github.com/jtackaberry/reaticulate/pull/211
+//----------------------------------------------------------------------------
+
+//! g="EastWest/Hollywood Opus Strings" n="1st Violins KS Master DIV A"
+//! m=""
+//! id=cd257d3a-dba6-4564-aa10-3db6fb91cb7c
+Bank * * 1st Violins KS Master DIV A
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long-dark i=accented-half o=note:25
+2 Sus Marc
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Strings" n="1st Violins KS Master DIV B"
+//! m=""
+//! id=9e37ac22-af97-4f25-a9ec-8faa5e9824f0
+Bank * * 1st Violins KS Master DIV B
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long-dark i=accented-half o=note:25
+2 Sus Marc
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Strings" n="1st Violins KS Master"
+//! m=""
+//! id=c3568ce5-b9bb-485b-b52d-7c9cce7bb6dd
+Bank * * 1st Violins KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long-dark i=accented-half o=note:25
+2 Sus Marc
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Strings" n="2nd Violins KS Master DIV A"
+//! m=""
+//! id=556dee2f-9dc9-41e0-a40b-63d519530934
+Bank * * 2nd Violins KS Master DIV A
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long-dark i=accented-half o=note:25
+2 Sus Marc
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short i=staccato o=note:27
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:28
+52 Marcato Short
+//! c=long-dark i=marcato-half o=note:29
+9 Marcato Long
+
+//! g="EastWest/Hollywood Opus Strings" n="2nd Violins KS Master DIV B"
+//! m=""
+//! id=e00a9719-79cf-4d60-a0e5-1aaf01fd524c
+Bank * * 2nd Violins KS Master DIV B
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long-dark i=accented-half o=note:25
+2 Sus Marc
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short i=staccato o=note:27
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:28
+52 Marcato Short
+//! c=long-dark i=marcato-half o=note:29
+9 Marcato Long
+
+//! g="EastWest/Hollywood Opus Strings" n="2nd Violins KS Master"
+//! m=""
+//! id=2c3d53f0-8624-4261-8757-fb91f494c696
+Bank * * 2nd Violins KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long-dark i=accented-half o=note:25
+2 Sus Marc
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short i=staccato o=note:27
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:28
+52 Marcato Short
+//! c=long-dark i=marcato-half o=note:29
+9 Marcato Long
+
+//! g="EastWest/Hollywood Opus Strings" n="18V KS Master"
+//! m=""
+//! id=f3782198-fbc3-4e9b-8757-43766c306630
+Bank * * 18V KS Master
+//! c=long i=note-half o=note:24
+1 Sus NV VB
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur + Port
+//! c=short-light i=spiccato o=note:27
+42 Spiccato
+//! c=short i=note-sixteenth o=note:28
+41 Staccatissimo
+//! c=short i=staccato o=note:29
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:30
+52 Marc Short
+//! c=long-dark i=marcato-half o=note:31
+9 Marc Vib Long
+//! c=long-light i=tremolo-sul-pont o=note:32
+13 Sul Pont Trem
+//! c=long-light i=flautando o=note:33
+8 Sul Tasto Flaut
+
+//! g="EastWest/Hollywood Opus Strings" n="Basses KS Master DIV A"
+//! m=""
+//! id=da4e563f-0759-4c06-89aa-9697185d7bde
+Bank * * Basses KS Master DIV A
+//! c=long i=note-half o=note:72
+1 Sus
+//! c=long-dark i=accented-half o=note:73
+2 Sus Marc
+//! c=legato i=legato o=note:74
+20 Leg Slur
+//! c=short-light i=spiccato o=note:75
+42 Staccatissimo
+//! c=short i=staccato o=note:76
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:77
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Strings" n="Basses KS Master DIV B"
+//! m=""
+//! id=6478af38-0ccb-4bb0-86c1-5852130e6e70
+Bank * * Basses KS Master DIV B
+//! c=long i=note-half o=note:72
+1 Sus
+//! c=long-dark i=accented-half o=note:73
+2 Sus Marc
+//! c=legato i=legato o=note:74
+20 Leg Slur
+//! c=short-light i=spiccato o=note:75
+42 Staccatissimo
+//! c=short i=staccato o=note:76
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:77
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Strings" n="Basses KS Master"
+//! m=""
+//! id=0ee3d8ee-44af-406e-9753-6c0dfa9d1853
+Bank * * Basses KS Master
+//! c=long i=note-half o=note:72
+1 Sus
+//! c=long-dark i=accented-half o=note:73
+2 Sus Marc
+//! c=legato i=legato o=note:74
+20 Leg Slur
+//! c=short-light i=spiccato o=note:75
+42 Staccatissimo
+//! c=short i=staccato o=note:76
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:77
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Strings" n="Celli KS Master DIV A"
+//! m=""
+//! id=6992db13-b982-42f7-9300-f8375d6338f0
+Bank * * Celli KS Master DIV A
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long-dark i=accented-half o=note:25
+2 Sus Marc
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Strings" n="Celli KS Master DIV B"
+//! m=""
+//! id=dd6c751f-6cd6-43c6-a009-51eddfa4e401
+Bank * * Celli KS Master DIV B
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long-dark i=accented-half o=note:25
+2 Sus Marc
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Strings" n="Celli KS Master"
+//! m=""
+//! id=c556e5b5-39a7-411d-81cc-95b00f744442
+Bank * * Celli KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long-dark i=accented-half o=note:25
+2 Sus Marc
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Strings" n="Violas KS Master DIV A"
+//! m=""
+//! id=1b109f93-3429-4ede-b28b-25e45a8345f9
+Bank * * Violas KS Master DIV A
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long-dark i=accented-half o=note:25
+2 Sus Marc
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Strings" n="Violas KS Master DIV B"
+//! m=""
+//! id=7fc055a0-7751-404d-a2ae-c46c938151a5
+Bank * * Violas KS Master DIV B
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long-dark i=accented-half o=note:25
+2 Sus Marc
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Strings" n="Violas KS Master"
+//! m=""
+//! id=5d684d7a-e63a-4fa2-9135-a6e42e3379e8
+Bank * * Violas KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long-dark i=accented-half o=note:25
+2 Sus Marc
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Stac On Bow
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Strings" n="ENS KS Master"
+//! m=""
+//! id=4a240280-82a9-4774-8bfd-cd1853259690
+Bank * * ENS KS Master
+//! c=long i=note-half o=note:24
+1 Sus Vib
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=long-dark i=tremolo-sul-pont o=note:26
+18 Sul Pont
+//! c=long-light i=sul-tasto o=note:27
+17 Sul Tasto
+//! c=short-light i=spiccato o=note:28
+42 Staccatissimo
+//! c=short i=staccato o=note:29
+40 Staccato
+
+//! g="EastWest/Hollywood Opus Strings" n="Full STR KS Master DIV A"
+//! m=""
+//! id=5f2bf8a5-5ff1-4212-bb07-5d54201e1a61
+Bank * * Full STR KS Master DIV A
+//! c=long i=note-half o=note:21
+1 Sus
+//! c=long-dark i=accented-half o=note:22
+2 Sus Marc
+//! c=legato i=legato o=note:23
+20 Sus + 1st Vln Leg
+//! c=short-light i=spiccato o=note:102
+42 Spiccato
+//! c=short i=staccato o=note:103
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:104
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Strings" n="Full STR KS Master DIV B"
+//! m=""
+//! id=4f07e703-98eb-40d4-9678-3a1fd929b2ca
+Bank * * Full STR KS Master DIV B
+//! c=long i=note-half o=note:21
+1 Sus
+//! c=long-dark i=accented-half o=note:22
+2 Sus Marc
+//! c=legato i=legato o=note:23
+20 Sus + 1st Vln Leg
+//! c=short-light i=spiccato o=note:102
+42 Spiccato
+//! c=short i=staccato o=note:103
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:104
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Strings" n="Full STR KS Master"
+//! m=""
+//! id=de5f8403-2bae-411d-83ba-2efd8d72a80f
+Bank * * Full STR KS Master
+//! c=long i=note-half o=note:21
+1 Sus
+//! c=long-dark i=accented-half o=note:22
+2 Sus Marc
+//! c=legato i=legato o=note:23
+20 Sus + 1st Vln Leg
+//! c=short-light i=spiccato o=note:102
+42 Spiccato
+//! c=short i=staccato o=note:103
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:104
+52 Marcato Short

--- a/userbanks/EastWest_Hollywood_Opus_Woodwinds.reabank
+++ b/userbanks/EastWest_Hollywood_Opus_Woodwinds.reabank
@@ -1,0 +1,263 @@
+//----------------------------------------------------------------------------
+// Source xshill: https://github.com/jtackaberry/reaticulate/pull/211
+//----------------------------------------------------------------------------
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="3BS KS Master"
+//! m=""
+//! id=7f42398f-e1ff-41ce-84a0-036e9fd9af2f
+Bank * * 3BS KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="3CL KS Master"
+//! m=""
+//! id=47f4f3cb-b50c-46f7-a6f0-d9f056b40483
+Bank * * 3CL KS Master
+//! c=long i=note-half o=note:24
+1 Sus Non Vib
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+//! c=long-dark i=marcato-half o=note:30
+9 Marcato Sus NV
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="3FL KS Master"
+//! m=""
+//! id=bbb27920-f41b-406f-868c-8d3a902a5fec
+Bank * * 3FL KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="AF KS Master"
+//! m=""
+//! id=77733563-4642-451d-b9b6-4364c70ef15e
+Bank * * AF KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short i=staccato o=note:27
+40 Staccato
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="BC KS Master"
+//! m=""
+//! id=b29d5090-c336-49ad-a2b4-2173c84dcf26
+Bank * * BC KS Master
+//! c=long i=note-half o=note:24
+1 Sus Non Vib
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="BF KS Master"
+//! m=""
+//! id=f6bfbc6b-d668-4322-9eea-55e23df586b7
+Bank * * BF KS Master
+//! c=long i=vibrato o=note:24
+1 Sus Vib
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short i=staccato o=note:27
+40 Staccato
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="BS KS Master"
+//! m=""
+//! id=4a314819-3592-46a9-a228-f8d5c38d87fc
+Bank * * BS KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="CB KS Master"
+//! m=""
+//! id=6332ed5d-300b-4926-b6c6-dc838997f4e0
+Bank * * CB KS Master
+//! c=long i=note-half o=note:60
+1 Sus
+//! c=long i=accented-half o=note:61
+2 Sus Accent
+//! c=legato i=legato o=note:62
+20 Leg Slur
+//! c=short-light i=spiccato o=note:63
+42 Staccatissimo
+//! c=short i=staccato o=note:64
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:65
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="CC KS Master"
+//! m=""
+//! id=b52e663c-859e-4bc7-96ee-3691d2fc2be8
+Bank * * CC KS Master
+//! c=long i=note-half o=note:72
+1 Sus Non Vib
+//! c=long i=accented-half o=note:73
+2 Sus Accent
+//! c=legato i=legato o=note:74
+20 Leg Slur
+//! c=short i=staccato o=note:75
+40 Staccato
+//! c=legato-dark i=legato-bowed2 o=note:76
+21 Leg Slur Accent
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="CL KS Master"
+//! m=""
+//! id=161b62b6-47a3-4b53-9487-67e683a2b963
+Bank * * CL KS Master
+//! c=long i=note-half o=note:24
+1 Sus Non Vib
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="CL2 KS Master"
+//! m=""
+//! id=685769ff-4bcc-45bd-92fa-ee6d45b969f4
+Bank * * CL2 KS Master
+//! c=long i=note-half o=note:24
+1 Sus Non Vib
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short i=staccato o=note:27
+40 Staccato
+//! c=legato-dark i=legato-bowed2 o=note:28
+21 Leg Slur Accent
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="EH KS Master"
+//! m=""
+//! id=11abac36-1037-4add-ad0a-ad3ba4f482d9
+Bank * * EH KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="FL KS Master"
+//! m=""
+//! id=38e4f897-6535-4b23-8889-6c0f47fd67d9
+Bank * * FL KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="FL2 KS Master"
+//! m=""
+//! id=d233e060-6e04-4309-8380-0039d2e49490
+Bank * * FL2 KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="OB KS Master"
+//! m=""
+//! id=1ce75c05-c28f-4991-b526-ff4f5ce5d760
+Bank * * OB KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Staccato
+//! c=short-dark i=marcato-quarter o=note:29
+52 Marcato Short
+
+//! g="EastWest/Hollywood Opus Woodwinds" n="PF KS Master"
+//! m=""
+//! id=867587c2-8384-4979-9639-f2129af5870f
+Bank * * PF KS Master
+//! c=long i=note-half o=note:24
+1 Sus
+//! c=long i=accented-half o=note:25
+2 Sus Accent
+//! c=legato i=legato o=note:26
+20 Leg Slur
+//! c=short-light i=spiccato o=note:27
+42 Staccatissimo
+//! c=short i=staccato o=note:28
+40 Staccato


### PR DESCRIPTION
I created some user banks for the EastWest Hollywood Opus edition keyswitches. The ones we already had in the repo were for the Play engine, and the keyswitch instruments that come with the Opus engine are different.